### PR TITLE
fix: admin cannot delete user comment

### DIFF
--- a/src/test/server/handlers/comments.ts
+++ b/src/test/server/handlers/comments.ts
@@ -55,9 +55,11 @@ export const commentsHandlers = [
           id: {
             equals: commentId,
           },
-          authorId: {
-            equals: user.id,
-          },
+          ...(user.role === 'USER' && {
+            authorId: {
+              equals: user.id,
+            },
+          }),
         },
       });
       persistDb('comment');


### PR DESCRIPTION
https://github.com/alan2207/bulletproof-react/blob/6f7d873bf6200b8fe6cceea7ceec5cede7856a25/src/test/server/handlers/comments.ts#L58-L60
This causes a bug that an admin account cannot delete the comment made by a user account. It can be safely removed because the commentId is enough to delete the comment.
 