### PR TITLE
Create prettier.config.js instead of .prettierrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,7 +68,7 @@ module.exports = {
         '@typescript-eslint/no-empty-function': ['off'],
         '@typescript-eslint/no-explicit-any': ['off'],
 
-        'prettier/prettier': ['error', {}, { usePrettierrc: true }],
+        'prettier/prettier': ['error'],
       },
     },
   ],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "printWidth": 100,
-  "tabWidth": 2,
-  "useTabs": false
-}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,10 @@
+module.exports = { // Prettier defaults
+  singleQuote: true, // singleQuote: true
+  trailingComma: "es5", // trailingComma: "es5"
+  printWidth: 100, // printWidth: 80
+  tabWidth: 2, // tabWidth: 2
+  useTabs: false, // useTabs: false
+  semi: true, // semi: true
+  endOfLine: "lf", // endOfLine: "lf"
+  bracketSpacing: true, // bracketSpacing: true
+}


### PR DESCRIPTION
### Rationale
1️⃣ I find it a waste of everyone's time to expect people to memorize the Prettier defaults.
2️⃣ If you want to use Airbnb's line length default (`printWidth: 100`), that's fine, but let's note that choice in a comment.

### Code changes
✅ chore: rename .prettierrc to prettier.config.js and add comments with Prettier defaults to indicate that a non-default value is being used for only printWidth
✅ chore: remove explicit "usePrettierrc: true" from .eslintrc.js (as this is the default setting, so just ["error"] is fine)

### Testing
✅ manually tested with `npm run lint`
✅ manually tested using VS Code extensions (Prettier, ESLint)

### Note
1️⃣ There is a line ending bug on Windows associated with erroring on ESLint; I'll submit a `.gitattributes` file to fix this in a separate PR.
2️⃣ I'm not 100% sure that `eslint --fix .` has the same behavior of `prettier --write .` [because Prettier **explicitly** has different rules for line length that ESLint does](https://prettier.io/docs/en/options.html#print-width). I always use Prettier then ESLint for linting, personally. That would need to be another PR.