### PR TITLE
[README] add Github Actions Status Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bulletproof React 🛡️ ⚛️
 
-[![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://github.com/tterb/atomic-design-ui/blob/master/LICENSEs)
+[![MIT License](https://img.shields.io/apm/l/atomic-design-ui.svg?)](https://github.com/tterb/atomic-design-ui/blob/master/LICENSEs) 
+[![CI](https://github.com/alan2207/bulletproof-react/actions/workflows/ci.yml/badge.svg)](https://github.com/alan2207/bulletproof-react/actions/workflows/ci.yml)
 
 A simple, scalable, and powerful architecture for building production ready React applications.
 


### PR DESCRIPTION
In association with: https://github.com/alan2207/bulletproof-react/pull/19

<img width="440" alt="Screen Shot 2021-08-31 at 5 44 39" src="https://user-images.githubusercontent.com/5501268/131403041-8d124839-4dce-440b-9b96-5270a14bacb7.png">

Personally, I think it's useful to be able to immediately check the Green or RED of the CI.

Thank you!