### PR TITLE
Material-UI is now MUI

### DIFF
--- a/docs/components-and-styling.md
+++ b/docs/components-and-styling.md
@@ -65,7 +65,7 @@ These component libraries come with their components fully styled.
 
 - [AntD](https://ant.design/) - another great component library that has a lot of different components. Best suitable for creating admin dashboards. However, it might be a bit difficult to change the styles in order to adapt it to a custom design.
 
-- [Material UI](https://material-ui.com/) - the most popular component library for React. Has a lot of different components. It might be more suitable for building admin dashboards as it would not be easy to change the components to look like something else than Material Design.
+- [MUI](https://mui.com/) - the most popular component library for React. Has a lot of different components. It might be more suitable for building admin dashboards as it would not be easy to change the components to look like something else than Material Design.
 
 #### Headless component libraries:
 


### PR DESCRIPTION
The blog post: https://mui.com/blog/material-ui-is-now-mui/.

---

It's also to be noticed that we have released a v5 https://mui.com/blog/mui-core-v5/ focusing on:

a. The DX to customize
b. Having a headless component library that can be used on its own: `@mui/core`
c. Having a styling solution that can be used on its own: `@mui/system`
d. Combining b. and c. to deliver Material Design: `@mui/material`