### PR TITLE
Added missing server cache state urls

### DIFF
--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -34,9 +34,9 @@ This is the state that comes from the server which is being cached on the client
 Good Server Cache Libraries:
 
 - [react-query](https://react-query.tanstack.com/) - REST + GraphQL
-- [swr]() - REST + GraphQL
-- [apollo client]() - GraphQL
-- [urql]() - GraphQl
+- [swr](https://swr.vercel.app/) - REST + GraphQL
+- [apollo client](https://www.apollographql.com/) - GraphQL
+- [urql](https://formidable.com/open-source/urql/) - GraphQl
 
 [Server State Example Code](../src/features/discussions/api/getDiscussions.ts)
 


### PR DESCRIPTION
There were some missing urls in the Server Cache State section in state-management.md.