### PR TITLE
fix: the`initMocks` function always starts

### DIFF
--- a/src/test/server/index.ts
+++ b/src/test/server/index.ts
@@ -1,5 +1,5 @@
 export const initMocks = () => {
-  if (!!process.env.REACT_APP_API_MOCKING === true) {
+  if (process.env.REACT_APP_API_MOCKING === 'true') {
     if (typeof window === 'undefined') {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const { server } = require('./server');


### PR DESCRIPTION
The value of `.env.*` files variables always string value. 
- ref: https://github.com/motdotla/dotenv/blob/master/README.md#what-rules-does-the-parsing-engine-follow