### PR TITLE
Remove unused import in smoke.ts

### DIFF
--- a/cypress/integration/smoke.ts
+++ b/cypress/integration/smoke.ts
@@ -4,8 +4,6 @@ import {
   commentGenerator,
 } from '../../src/test/data-generators';
 
-import { formatDate } from '../../src/utils/format';
-
 describe('smoke', () => {
   it('should handle normal app flow', () => {
     const user = userGenerator();


### PR DESCRIPTION
Imported `formatDate` in `cypress/integration/smoke.ts` is currently not used. I think we can delete the line.