### PR TITLE
Change Axios config to updated type to fix compiler error

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,10 +1,10 @@
-import Axios, { AxiosRequestConfig } from 'axios';
+import Axios, { InternalAxiosRequestConfig } from 'axios';
 
 import { API_URL } from '@/config';
 import { useNotificationStore } from '@/stores/notifications';
 import storage from '@/utils/storage';
 
-function authRequestInterceptor(config: AxiosRequestConfig) {
+function authRequestInterceptor(config: InternalAxiosRequestConfig) {
   const token = storage.getToken();
   if (token) {
     config.headers.authorization = `${token}`;


### PR DESCRIPTION
The type signature has changed for Axios request configs. The current typing causes a compiler error. This PR updates the config to the newer typing and corrects the error.