### PR TITLE
Use main-branch for GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   all-cli-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub recommends using the naming `main` for the default branch, and I think this package should respect that recommendation as well.