### PR TITLE
Vscode Intellisense alias path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }


### PR DESCRIPTION
I think automatically suggesting relative imports by vscode intellisense is an addition that plays nicely with the recommendations in the docs