### PR TITLE
Update state-management.md old React documentation links

### DIFF
--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -18,7 +18,7 @@ This is the state that controls interactive parts of an application. Opening mod
 Good Application State Solutions:
 
 - [context](https://react.dev/learn/passing-data-deeply-with-context) + [hooks](https://react.dev/reference/react-dom/hooks)
-- [redux](https://redux.js.org/) + [redux tolkit](https://redux-toolkit.js.org/)
+- [redux](https://redux.js.org/) + [redux toolkit](https://redux-toolkit.js.org/)
 - [mobx](https://mobx.js.org)
 - [zustand](https://github.com/pmndrs/zustand)
 - [constate](https://github.com/diegohaz/constate)

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -6,8 +6,8 @@ There is no need to keep all of your state in a single centralized store. There 
 
 This is the state that only a component needs, and it is not meant to be shared anywhere else. But you can pass it as prop to children components if needed. Most of the time, you want to start from here and lift the state up if needed elsewhere. For this type of state, you will usually need:
 
-- [useState](https://reactjs.org/docs/hooks-reference.html#usestate) - for simpler states that are independent
-- [useReducer](https://reactjs.org/docs/hooks-reference.html#usereducer) - for more complex states where on a single action you want to update several pieces of state
+- [useState](https://react.dev/reference/react/useState) - for simpler states that are independent
+- [useReducer](https://react.dev/reference/react/useReducer) - for more complex states where on a single action you want to update several pieces of state
 
 [Component State Example Code](../src/components/Layout/MainLayout.tsx)
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -17,8 +17,8 @@ This is the state that controls interactive parts of an application. Opening mod
 
 Good Application State Solutions:
 
-- [context](https://reactjs.org/docs/context.html) + [hooks](https://reactjs.org/docs/hooks-intro.html)
-- [redux](https://redux.js.org/) + [redux toolkit](https://redux-toolkit.js.org/)
+- [context](https://react.dev/learn/passing-data-deeply-with-context) + [hooks](https://react.dev/reference/react-dom/hooks)
+- [redux](https://redux.js.org/) + [redux tolkit](https://redux-toolkit.js.org/)
 - [mobx](https://mobx.js.org)
 - [zustand](https://github.com/pmndrs/zustand)
 - [constate](https://github.com/diegohaz/constate)


### PR DESCRIPTION
* https://reactjs.org/docs/hooks-reference.html#usestate redirects to https://legacy.reactjs.org/docs/hooks-reference.html#usestate

* https://reactjs.org/docs/hooks-reference.html#usereducer redirects to https://legacy.reactjs.org/docs/hooks-reference.html#usereducer

These links are outdated as stated as the alert message displayed on the pages.

I propose to change those links to the proposed new React documentation ones.