### PR TITLE
[minor]: Typo in ~/README.md and docs/security.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repo doesn't aim to be a silver bullet for all React applications as there 
 
 This is not supposed to be a template, boilerplate or a framework. It is an opinionated guide that shows how to do some things in a certain way. You are not forced to do everything exactly as it is shown here, decide what works best for you and your team and stay consistent with your style.
 
-To get most out of it, do not get limited by the technologies used in this sample app, but rather focus on the principles and the concepts that are being presented here. The tools and libraries used here are just a suggestion, you can always replace them with something that fits your needs better Sometimes, your project might require a slightly different approach, and that's totally fine.
+To get most out of it, do not get limited by the technologies used in this sample app, but rather focus on the principles and the concepts that are being presented here. The tools and libraries used here are just a suggestion, you can always replace them with something that fits your needs better. Sometimes, your project might require a slightly different approach, and that's totally fine.
 
 ## Table Of Contents:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,6 +55,6 @@ In a role-based authorization model, access to resources is determined by defini
 
 While Role-Based Access Control (RBAC) provides a structured methodology for authorization, there are instances where a more granular approach is necessary. Precision-Based Access Control (PBAC) offers a more flexible solution, particularly in scenarios where access permissions need to be finely tuned based on specific criteria, such as allowing only the owner of a resource to perform certain operations. For example, in the case of a user's comment, PBAC ensures that only the author of the comment has the privilege to delete it, adding a layer of precision and customization to access control mechanisms.
 
-For RBAC protection you can use the `RBAC` component by passing allowed roles to it. On the other hand if you need more strict protection, you can pass policies check to it.
+For RBAC protection, you can use the `RBAC` component by passing allowed roles to it. On the other hand if you need more strict protection, you can pass policies check to it.
 
 [PBAC Example Code](../src/features/comments/components/comments-list.tsx)

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,6 +55,6 @@ In a role-based authorization model, access to resources is determined by defini
 
 While Role-Based Access Control (RBAC) provides a structured methodology for authorization, there are instances where a more granular approach is necessary. Precision-Based Access Control (PBAC) offers a more flexible solution, particularly in scenarios where access permissions need to be finely tuned based on specific criteria, such as allowing only the owner of a resource to perform certain operations. For example, in the case of a user's comment, PBAC ensures that only the author of the comment has the privilege to delete it, adding a layer of precision and customization to access control mechanisms.
 
-For RBAC protection, you can use the `RBAC` component by passing allowed roles to it. On the other hand if you need more strict protection, you can pass policies check to it.
+For RBAC protection, you can use the `RBAC` component by passing allowed roles to it. On the other hand, if you need more strict protection, you can pass policies check to it.
 
 [PBAC Example Code](../src/features/comments/components/comments-list.tsx)


### PR DESCRIPTION
Fixes #156