### PR TITLE
Add timeouts to "should create, render and delete discussions" test

### DIFF
--- a/src/app/routes/app/discussions/__tests__/discussions.test.tsx
+++ b/src/app/routes/app/discussions/__tests__/discussions.test.tsx
@@ -20,69 +20,77 @@ afterAll(() => {
   (console.error as Mock).mockRestore();
 });
 
-test('should create, render and delete discussions', async () => {
-  await renderApp(<DiscussionsRoute />);
+test(
+  'should create, render and delete discussions',
+  { timeout: 10000 },
+  async () => {
+    await renderApp(<DiscussionsRoute />);
 
-  const newDiscussion = createDiscussion();
+    const newDiscussion = createDiscussion();
 
-  expect(await screen.findByText(/no entries/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no entries/i)).toBeInTheDocument();
 
-  await userEvent.click(
-    screen.getByRole('button', { name: /create discussion/i }),
-  );
+    await userEvent.click(
+      screen.getByRole('button', { name: /create discussion/i }),
+    );
 
-  const drawer = await screen.findByRole('dialog', {
-    name: /create discussion/i,
-  });
+    const drawer = await screen.findByRole('dialog', {
+      name: /create discussion/i,
+    });
 
-  const titleField = within(drawer).getByText(/title/i);
-  const bodyField = within(drawer).getByText(/body/i);
+    const titleField = within(drawer).getByText(/title/i);
+    const bodyField = within(drawer).getByText(/body/i);
 
-  await userEvent.type(titleField, newDiscussion.title);
-  await userEvent.type(bodyField, newDiscussion.body);
+    await userEvent.type(titleField, newDiscussion.title);
+    await userEvent.type(bodyField, newDiscussion.body);
 
-  const submitButton = within(drawer).getByRole('button', {
-    name: /submit/i,
-  });
+    const submitButton = within(drawer).getByRole('button', {
+      name: /submit/i,
+    });
 
-  await userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
-  await waitFor(() => expect(drawer).not.toBeInTheDocument());
+    await waitFor(() => expect(drawer).not.toBeInTheDocument());
 
-  const row = await screen.findByRole('row', {
-    name: `${newDiscussion.title} ${formatDate(newDiscussion.createdAt)} View Delete Discussion`,
-  });
+    const row = await screen.findByRole(
+      'row',
+      {
+        name: `${newDiscussion.title} ${formatDate(newDiscussion.createdAt)} View Delete Discussion`,
+      },
+      { timeout: 5000 },
+    );
 
-  expect(
-    within(row).getByRole('cell', {
-      name: newDiscussion.title,
-    }),
-  ).toBeInTheDocument();
+    expect(
+      within(row).getByRole('cell', {
+        name: newDiscussion.title,
+      }),
+    ).toBeInTheDocument();
 
-  await userEvent.click(
-    within(row).getByRole('button', {
+    await userEvent.click(
+      within(row).getByRole('button', {
+        name: /delete discussion/i,
+      }),
+    );
+
+    const confirmationDialog = await screen.findByRole('dialog', {
       name: /delete discussion/i,
-    }),
-  );
+    });
 
-  const confirmationDialog = await screen.findByRole('dialog', {
-    name: /delete discussion/i,
-  });
+    const confirmationDeleteButton = within(confirmationDialog).getByRole(
+      'button',
+      {
+        name: /delete discussion/i,
+      },
+    );
 
-  const confirmationDeleteButton = within(confirmationDialog).getByRole(
-    'button',
-    {
-      name: /delete discussion/i,
-    },
-  );
+    await userEvent.click(confirmationDeleteButton);
 
-  await userEvent.click(confirmationDeleteButton);
+    await screen.findByText(/discussion deleted/i);
 
-  await screen.findByText(/discussion deleted/i);
-
-  expect(
-    within(row).queryByRole('cell', {
-      name: newDiscussion.title,
-    }),
-  ).not.toBeInTheDocument();
-});
+    expect(
+      within(row).queryByRole('cell', {
+        name: newDiscussion.title,
+      }),
+    ).not.toBeInTheDocument();
+  },
+);


### PR DESCRIPTION
Got two problems related to timeouts when executing this test. I added some more time to handle them.

![Capture](https://github.com/alan2207/bulletproof-react/assets/13167621/143ef1ff-b598-493e-aa14-7216fedd4dc6)

![Capture2](https://github.com/alan2207/bulletproof-react/assets/13167621/44ad6d27-1e1e-4968-86cd-fb6c47b80014)
