### PR TITLE
Fix Markdown formatting of `project-structure.md` file

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -58,8 +58,6 @@ NOTE: You don't need all of these folders for every feature. Only include the on
 
 In some cases it might be more practical to keep all API calls outside of the features folders in a dedicated `api` folder where all API calls are defined. This can be useful if you have a lot of shared API calls between features.
 
-````sh
-
 In the past, it was recommended to use barrel files to export all the files from a feature. However, it can cause issues for Vite to do tree shaking and can lead to performance issues. Therefore, it is recommended to import the files directly.
 
 It might not be a good idea to import across the features. Instead, compose different features at the application level. This way, you can ensure that each feature is independent which makes the codebase less convoluted.
@@ -103,7 +101,7 @@ To forbid cross-feature imports, you can use ESLint:
         ],
     },
 ],
-````
+```
 
 You might also want to enforce unidirectional codebase architecture. This means that the code should flow in one direction, from shared parts of the code to the application (shared -> features -> app). This is a good practice to follow as it makes the codebase more predictable and easier to understand.
 


### PR DESCRIPTION
I'm not sure if this was intentional or not, but it looks like there was some accidental code-block formatting left as part of https://github.com/alan2207/bulletproof-react/pull/194/files#diff-f4f155ac59b8fed51a3f98e2341308b2635b8096ba3a56a94531205f84257af9R61-R106.

Before | After
--- | ---
<img width="1102" alt="Screenshot 2024-09-21 at 00 32 13" src="https://github.com/user-attachments/assets/05bf0aeb-3fab-44dc-b825-219db097cc87"> | <img width="1103" alt="Screenshot 2024-09-21 at 00 34 30" src="https://github.com/user-attachments/assets/c4ae256c-8172-40b4-99fb-0075a479e2ef">
