### PR TITLE
Add error state to login and register forms

### DIFF
--- a/apps/nextjs-app/src/components/ui/form/error.tsx
+++ b/apps/nextjs-app/src/components/ui/form/error.tsx
@@ -1,15 +1,19 @@
+import { ComponentPropsWithoutRef } from 'react';
+
+import { cn } from '@/utils/cn';
+
 export type ErrorProps = {
   errorMessage?: string | null;
-};
+} & ComponentPropsWithoutRef<'div'>;
 
-export const Error = ({ errorMessage }: ErrorProps) => {
+export const Error = ({ errorMessage, className }: ErrorProps) => {
   if (!errorMessage) return null;
 
   return (
     <div
       role="alert"
       aria-label={errorMessage}
-      className="text-sm font-semibold text-red-500"
+      className={cn('text-sm font-semibold text-red-500', className)}
     >
       {errorMessage}
     </div>

--- a/apps/nextjs-app/src/features/auth/components/login-form.tsx
+++ b/apps/nextjs-app/src/features/auth/components/login-form.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
 import { Form, Input } from '@/components/ui/form';
+import { Error } from '@/components/ui/form/error';
 import { paths } from '@/config/paths';
 import { useLogin, loginInputSchema } from '@/lib/auth';
 
@@ -13,17 +14,17 @@ type LoginFormProps = {
 };
 
 export const LoginForm = ({ onSuccess }: LoginFormProps) => {
-  const login = useLogin({
+  const { mutate, isPending, error } = useLogin({
     onSuccess,
   });
-
   const searchParams = useSearchParams();
   const redirectTo = searchParams?.get('redirectTo');
+
   return (
     <div>
       <Form
         onSubmit={(values) => {
-          login.mutate(values);
+          mutate(values);
         }}
         schema={loginInputSchema}
       >
@@ -42,11 +43,8 @@ export const LoginForm = ({ onSuccess }: LoginFormProps) => {
               registration={register('password')}
             />
             <div>
-              <Button
-                isLoading={login.isPending}
-                type="submit"
-                className="w-full"
-              >
+              {error && <Error className="mb-2" errorMessage={error.message} />}
+              <Button isLoading={isPending} type="submit" className="w-full">
                 Log in
               </Button>
             </div>

--- a/apps/nextjs-app/src/features/auth/components/register-form.tsx
+++ b/apps/nextjs-app/src/features/auth/components/register-form.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Form, Input, Select, Label, Switch } from '@/components/ui/form';
+import { Error } from '@/components/ui/form/error';
 import { paths } from '@/config/paths';
 import { useRegister, registerInputSchema } from '@/lib/auth';
 import { Team } from '@/types/api';
@@ -24,6 +25,7 @@ export const RegisterForm = ({
   teams,
 }: RegisterFormProps) => {
   const registering = useRegister({ onSuccess });
+  const { mutate, isPending, error } = useRegister({ onSuccess });
   const searchParams = useSearchParams();
   const redirectTo = searchParams?.get('redirectTo');
 
@@ -31,7 +33,7 @@ export const RegisterForm = ({
     <div>
       <Form
         onSubmit={(values) => {
-          registering.mutate(values);
+          mutate(values);
         }}
         schema={registerInputSchema}
         options={{
@@ -96,11 +98,8 @@ export const RegisterForm = ({
               />
             )}
             <div>
-              <Button
-                isLoading={registering.isPending}
-                type="submit"
-                className="w-full"
-              >
+              {error && <Error className="mb-2" errorMessage={error.message} />}
+              <Button isLoading={isPending} type="submit" className="w-full">
                 Register
               </Button>
             </div>


### PR DESCRIPTION
Hello, was just trying the repo out and when I forgot to start the API server, there was no clear error message. IMO production apps would at least a message to show to the users if they weren't able to log in or register.

- Add a simple error message for potential server errors for just the first two screens, login and register. (It could be more declarative, I just returned the actual error message for now).
- Needed to add `className` prop to Error for the error message too cramped.


| Login | Register |
| :-: | :-: |
| ![image](https://github.com/user-attachments/assets/c315af82-3368-4226-a265-064f4f8cb204) | ![image](https://github.com/user-attachments/assets/9db4de57-8529-471d-86cb-780bc1a91502) | 


## Caveat

- Didn't add for the other forms yet and didn't add the tests yet